### PR TITLE
Improve logic in selecting rules 

### DIFF
--- a/src/app/components/permission-table/permission-table.component.html
+++ b/src/app/components/permission-table/permission-table.component.html
@@ -30,7 +30,7 @@
           <button *ngFor="let rule of rule_group.rules"
             [className]="getClass(rule)"
             [disabled]="isDisabled(rule)"
-            (click)="selectOrDeselect(rule)"
+            (click)="selectOrDeselect(rule, rule_group)"
           >
             {{rule.operation | titlecase}}
           </button>


### PR DESCRIPTION
When selecting edit/create/delete rule, select also the view rule. 
When removing view rule, also remove edit/create/delete rules

This prevents that users can edit/delete/create resources but are not allowed to view them (which is a strange situation that should be avoided).