### PR TITLE
Don't update value in UI if PATCH request fails

### DIFF
--- a/src/app/components/edit/base-edit/base-edit.component.ts
+++ b/src/app/components/edit/base-edit/base-edit.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { UserPermissionService } from 'src/app/auth/services/user-permission.service';
 import { Organization } from 'src/app/interfaces/organization';
-import { User } from 'src/app/interfaces/user';
 import { BaseApiService } from 'src/app/services/api/base-api.service';
 import { ModalService } from 'src/app/services/common/modal.service';
 import { UtilsService } from 'src/app/services/common/utils.service';
@@ -103,20 +102,26 @@ export abstract class BaseEditComponent implements OnInit {
       request = this.apiService.update(resource);
     }
 
-    let data = await request.toPromise().catch((error: any) => {
-      this.modalService.openMessageModal(ModalMessageComponent, [
-        error.error.msg,
-      ]);
-      return null;
-    });
-
-    if (this.mode === OpsType.CREATE) {
-      resource.id = data.id;
-      this.dataService.save(resource);
-    }
-    if (goToPreviousPage) {
-      this.utilsService.goToPreviousPage();
-    }
-    return data;
+    return request
+      .toPromise()
+      .then((data) => {
+        // save the ID that newly created data had
+        if (this.mode === OpsType.CREATE) {
+          resource.id = data.id;
+          this.dataService.save(resource);
+        }
+        if (goToPreviousPage) {
+          this.utilsService.goToPreviousPage();
+        }
+        return data;
+      })
+      .catch((error) => {
+        let error_msg = 'An unknown error occurred!';
+        if (error.error.msg) {
+          error_msg = error.error.msg;
+        }
+        this.modalService.openMessageModal(ModalMessageComponent, [error_msg]);
+        return null;
+      });
   }
 }

--- a/src/app/components/edit/organization-edit/organization-edit.component.ts
+++ b/src/app/components/edit/organization-edit/organization-edit.component.ts
@@ -70,11 +70,19 @@ export class OrganizationEditComponent
 
   async save(): Promise<void> {
     const new_public_key = await this.readUploadedFile();
+
+    let old_public_key = this.organization.public_key;
     if (new_public_key) {
       this.organization.public_key = new_public_key;
     }
     let org_json = await super.save(this.organization, false);
-    this.router.navigate([`/organization/${org_json.id}`]);
+
+    // reset public key if saving organization failed
+    if (org_json === null) {
+      this.organization.public_key = old_public_key;
+    } else {
+      this.router.navigate([`/organization/${org_json.id}`]);
+    }
   }
 
   uploadPublicKey($event: any): void {

--- a/src/app/components/organization/organization.component.ts
+++ b/src/app/components/organization/organization.component.ts
@@ -261,7 +261,7 @@ export class OrganizationComponent implements OnInit {
     if (this.current_organization.public_key)
       this.fileService.downloadTxtFile(
         this.current_organization.public_key,
-        `public_key_organization_${this.current_organization.name}.pub`
+        `public_key_organization_${this.current_organization.name}.txt`
       );
   }
 

--- a/src/app/services/common/file.service.ts
+++ b/src/app/services/common/file.service.ts
@@ -26,6 +26,7 @@ export class FileService {
         const content = fileReader.result?.toString();
         resolve(content);
       };
+      fileReader.onerror = reject;
       fileReader.readAsText(file);
     });
   }


### PR DESCRIPTION
If a resource is patched, but the request returns an error, prevent that the resource is updated in the UI

Also a few fixes for public key uploads

fix #55 