### PR TITLE
Include ARR affinity credentials when sending cookie request so that …

### DIFF
--- a/src/app/services/socketio-connect.service.ts
+++ b/src/app/services/socketio-connect.service.ts
@@ -23,6 +23,7 @@ export class SocketioConnectService {
       // connect to tasks namespace
       const namespace = '/tasks';
       this.socket = io(`${environment.server_url}${namespace}`, {
+        withCredentials: true,
         extraHeaders: {
           Authorization: `Bearer ${token}`
         }


### PR DESCRIPTION
…sticky sessions are functioning properly

Fix #227 